### PR TITLE
comment out GIST creation link (broken)

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,7 +189,9 @@
     <p class="t" data-t="[html]export.generic_download_copy" id="export-raw"></p>
     <p class="t" data-t="[html]export.raw_interpreter"></p>
     <p><span class="t" data-t="export.editors"></span> <a id="export-editors-josm" href="">JOSM</a>, <a id="export-editors-level0" href="" target="_blank" class="external">Level0</a></p>
+    <!--
     <p class="t" data-t="[html]export.save_geoJSON_gist"></p>
+    -->
     </div>
     <h4 class="t" data-t="export.section.map"></h4>
     <div>


### PR DESCRIPTION
GIST export is broken due to github disabling anonymous GIST creation (#369)